### PR TITLE
Add support for subscribing to subkeys

### DIFF
--- a/lib/core/stoxy-storage.js
+++ b/lib/core/stoxy-storage.js
@@ -264,27 +264,28 @@ function writeToKeyInStore(key, data, db, resolve, reject) {
         const finalKey = keyParts.shift();
         elementReference[finalKey] = data;
 
-        writeToStore(topLevelKey, dataToWrite, db, resolve, reject);
+        writeToStore(topLevelKey, dataToWrite, db, resolve, reject, key);
     });
 }
 
-function writeToStore(key, data, db, resolve, reject) {
+function writeToStore(key, data, db, resolve, reject, originalKey) {
+    if (originalKey === undefined) originalKey = key;
     if (!canUseIDB() || !hasIDBAccess || !shouldPersist(key)) {
         updateCache(key, data);
-        doEvent(PUT_SUCCESS, { key, data });
+        doEvent(PUT_SUCCESS, { key: originalKey, data });
         return resolve({ key, data });
     }
-    const transaction = createWriteTransaction(key, data, db, resolve, reject);
+    const transaction = createWriteTransaction(key, data, db, resolve, reject, originalKey);
     const objectStore = transaction.objectStore(STOXY_DATA_STORAGE);
     objectStore.put(data, key);
     // No need to resolve here since it's done inside the transaction
 }
 
-function createWriteTransaction(key, data, db, resolve, reject) {
+function createWriteTransaction(key, data, db, resolve, reject, originalKey) {
     const transaction = db.transaction([STOXY_DATA_STORAGE], 'readwrite');
     transaction.oncomplete = event => {
         invalidateCache(key);
-        doEvent(PUT_SUCCESS, { key, data });
+        doEvent(PUT_SUCCESS, { key: originalKey, data });
         resolve({ key, data });
     };
     transaction.onerror = event => {

--- a/test/sub.test.js
+++ b/test/sub.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@esm-bundle/chai';
-import { write, read, clear, sub, remove } from '../lib/core';
+import { write, update, read, clear, sub, remove } from '../lib/core';
 
 it('Should react to sub events', async () => {
     let foo = 0;
@@ -13,4 +13,30 @@ it('Should react to sub events', async () => {
     await write("stoxy-state", "foooo");
 
     expect(foo).to.equal(4);
+})
+
+it('Should react to sub events on subkeys', async () => {
+    let foo = 0;
+    sub("stoxy-state.bar.counter", (e) => {
+        foo += 1
+    });
+
+    write("stoxy-state", {
+        foo: "ff",
+        bar: {
+            counter: 0
+        }
+    });
+    clear("stoxy-state");
+    write("stoxy-state",
+        {
+            foo: "ff",
+            bar: {
+                counter: 0
+            }
+        }
+    );
+    await update("stoxy-state.bar.counter", c => c += 1);
+
+    expect(foo).to.equal(1);
 })


### PR DESCRIPTION
I was thinking of implementing a diffing tool for the updates, but thinking about it now, I don't now if it's the responsibility of Stoxy.

Stoxy doesn't store have a direct ref of the previous state of the state object and therefore would have to fetch it to do the diffing and I don't know if I want to force a read operation on the write operation.